### PR TITLE
Use nightly docker container from docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM rust:1.50
+FROM rustlang/rust:nightly
 
 WORKDIR /usr/src/app
 
 COPY . .
-
-RUN rustup toolchain install nightly && \
-    rustup default nightly
 
 RUN cargo build --release
 


### PR DESCRIPTION
Instead of downloading manually using `rustup`, it is better to use the [officially supported container](https://github.com/rust-lang/docker-rust-nightly).